### PR TITLE
[sorted table] 데이터가 변경되면 테이블을 다시 정렬

### DIFF
--- a/dist/useSortableTable/index.js
+++ b/dist/useSortableTable/index.js
@@ -41,10 +41,10 @@ compareFn) => {
         const targetColumn = convertedData.get(key || keys[0]);
         if (targetColumn === undefined) {
             console.error('Can not find key in data');
-            return Array((_a = convertedData.get(key || keys[0])) === null || _a === void 0 ? void 0 : _a.length).fill(null).map((_, i) => i);
+            return ((_a = convertedData.get(key || keys[0])) === null || _a === void 0 ? void 0 : _a.map((_, i) => i)) || [];
         }
         if (!compareFn) {
-            return Array(targetColumn.length).fill(null).map((_, i) => i);
+            return targetColumn.map((_, i) => i);
         }
         const sortedIndex = targetColumn
             .map((v, i) => ({ v, i }))
@@ -63,6 +63,7 @@ const useSortableTable = (data) => {
     const [convertedData, setConvertedData] = react.useState(_initalizeConvertedData(data));
     const [key, setKey] = react.useState();
     const [compareFn, setCompareFn] = react.useState();
+    const sortedData = react.useMemo(() => _revertDataInOrder(convertedData, key, compareFn), [convertedData, key, compareFn]);
     react.useEffect(() => {
         setConvertedData(_initalizeConvertedData(data));
     }, [data]);
@@ -87,7 +88,7 @@ const useSortableTable = (data) => {
     const sortableTable = {
         sort,
         initializeSort,
-        sortedData: _revertDataInOrder(convertedData, key, compareFn)
+        sortedData
     };
     return sortableTable;
 };

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 type SortableTableDataType<V extends Object> = Map<keyof V, Array<V[keyof V]>>;
 
+const unique = <T,>(val: T, idx: number, arr: T[]) => arr.indexOf(val) === idx;
+
 const _initalizeConvertedData = <V extends Object,>(data: V[], keys: (keyof V)[]) => {
     const initTableData: SortableTableDataType<V> = new Map();
 
@@ -28,40 +30,60 @@ const useSortableTable = <V extends Object>(data: V[]) => {
 
     const [convertedData, setConvertedData] = useState<SortableTableDataType<V> | undefined>(undefined);
     const [sortedData, setSortedData] = useState<V[]>(() => data);
+    const [key, setKey] = useState<K>();
+    const [compareFn, setCompareFn] = useState<(a: any, b: any) => number>();
 
     useEffect(() => {
         if (data.length === 0) {
             return;
         }
-        setSortedData(data);
+        const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
+
         setConvertedData(_initalizeConvertedData(data, keys));
     }, [data]);
-
-    const keys = useMemo(() => {
-        const objectKeys = data.reduce((lhs, rhs) => {
-            const currentValueKeys = Object.keys(rhs) as K[];
-
-            const newObjectKeys = currentValueKeys.filter((key) => !lhs.includes(key));
-
-            return [...lhs, ...newObjectKeys];
-        }, [] as K[]);
-
-        return objectKeys;
-    }, [data]);
     
+    /** validate params and pass key, compareFn */
     const sort = useCallback((key: K, compareFn: (a: any, b: any) => number) => {
-        if (keys.length === 0) {
-            return;
-        }
-
         if (convertedData === undefined) {
             throw new Error('tableData is not initialized');
+        }
+
+        if (!key || !compareFn){
+            throw new Error('sort parameters are not given');
+        }
+
+        const keys = [...convertedData.keys()];
+
+        if (keys.length === 0) {
+            return;
         }
 
         const targetColumn = convertedData.get(key);
 
         if (targetColumn === undefined) {
             throw new Error('Can not find key in data');
+        }
+
+        setKey(key);
+        setCompareFn(()=>compareFn);
+
+    }, [convertedData]);
+
+    /** sort data depends on convertedData, key, compareFn */
+    useEffect(()=>{
+        if (!convertedData || !key || !compareFn){
+            return;
+        }
+        
+        const keys = [...convertedData.keys()];
+        
+        const targetColumn = convertedData.get(key);
+
+        if (targetColumn === undefined) {
+            setKey(undefined);
+            setCompareFn(undefined);
+            console.error('Can not find key in data');
+            return;
         }
 
         const sortedIndex = targetColumn
@@ -71,28 +93,26 @@ const useSortableTable = <V extends Object>(data: V[]) => {
 
         const newSortedData = sortedIndex.map((index) =>
             keys.map((key) => {
-                const value = convertedData.get(key);
-
-                if (!value) {
-                    throw new Error('Can not find key in data');
-                }
-
-                return { [key]: value[index] };
+                return { [key]: targetColumn[index] };
             }).reduce((lhs, rhs) => {
                 return {...lhs, ...rhs}; 
             }, {} as V)
         );
-
-            setSortedData(newSortedData);
-        }, [convertedData, keys]);
+        
+        setSortedData(newSortedData);
+    
+    },[convertedData, key, compareFn])
 
     const initializeSort = useCallback(() => {
+
+        const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
+
         if (keys.length === 0) {
             return;
         }
         setConvertedData(_initalizeConvertedData(data, keys));
         setSortedData(data);
-    }, [data, keys]);
+    }, [data]);
 
     const sortableTable = {
         sort,

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 type SortableTableDataType<V extends Object> = Map<keyof V, Array<V[keyof V]>>;
 
@@ -87,6 +87,7 @@ const useSortableTable = <V extends Object>(data: V[]) => {
     const [convertedData, setConvertedData] = useState<SortableTableDataType<V> | undefined>(_initalizeConvertedData(data));
     const [key, setKey] = useState<K>();
     const [compareFn, setCompareFn] = useState<(a: any, b: any) => number>();
+    const sortedData = useMemo(()=>_revertDataInOrder(convertedData, key, compareFn),[convertedData, key, compareFn]);
 
     useEffect(() => {
 
@@ -123,7 +124,7 @@ const useSortableTable = <V extends Object>(data: V[]) => {
     const sortableTable = {
         sort,
         initializeSort,
-        sortedData: _revertDataInOrder(convertedData, key, compareFn)
+        sortedData
     };
 
     return sortableTable;

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -7,7 +7,7 @@ const unique = <T,>(val: T, idx: number, arr: T[]) => arr.indexOf(val) === idx;
 const _initalizeConvertedData = <V extends Object,>(data: V[]) => {
     type K = keyof V;
     const initTableData: SortableTableDataType<V> = new Map();
-    const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
+    const keys = data.flatMap(row => Object.keys(row) as K[]).filter(unique);
 
     if (keys.length === 0) {
         return initTableData;
@@ -67,7 +67,7 @@ const _revertDataInOrder = <V extends object>(
             .sort((a, b) => compareFn(a.v, b.v))
             .map((sorted) => sorted.i);
         
-            return sortedIndex;
+        return sortedIndex;
     })();
         
     const sortedData = order.map((index) => 

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -55,11 +55,11 @@ const _revertDataInOrder = <V extends object>(
     
         if (targetColumn === undefined) {
             console.error('Can not find key in data');
-            return Array(convertedData.get(key || keys[0])?.length).fill(null).map((_,i) => i);
+            return convertedData.get(key || keys[0])?.map((_,i) => i) || [];
         }
 
         if (!compareFn){
-            return Array(targetColumn.length).fill(null).map((_,i) => i);
+            return targetColumn.map((_,i) => i);
         }
     
         const sortedIndex = targetColumn

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 type SortableTableDataType<V extends Object> = Map<keyof V, Array<V[keyof V]>>;
 
@@ -17,7 +17,6 @@ const _initalizeConvertedData = <V extends Object,>(data: V[]) => {
         initTableData.set(key, []);
     });
 
-
     data.forEach((rowData) => {
         (Object.keys(rowData) as (keyof V)[]).forEach((key) => {
             const targetMapArray = initTableData.get(key);
@@ -32,72 +31,67 @@ const _initalizeConvertedData = <V extends Object,>(data: V[]) => {
     return initTableData;
 }
 
-
-    /** sort data depends on convertedData, key, compareFn */
-const _updateSortedData = <V extends object>(
-    convertedData: SortableTableDataType<V>,
-    setSortedData: React.Dispatch<React.SetStateAction<V[]>>,
-    key?: keyof V,
-    compareFn?: (a: any, b: any) => number
-)=>{
-    
-    const revertDataInOrder = <V extends object>(convertedData: SortableTableDataType<V>, order?: number[]) => {
-
-        const keys = [...convertedData.keys()];
-            
-        const sortedIndex = order
-            ?? Array(convertedData.get(keys[0])?.length).fill(null).map((v,index) => index);
-
-        const sortedData = sortedIndex.map((index) => 
-            keys.map((key) => {
-                return { [key]: (convertedData.get(key)||[])[index] };
-            }).reduce((lhs, rhs) => {
-                return {...lhs, ...rhs}; 
-            }, {} as V)
-        )
-
-        return sortedData;
-    }
+/**
+ * 
+ * @param convertedData 
+ * @param key key가 주어지지 않은 경우 아무 키(구현상에서는 첫번째 키)를 사용, 최초의 정렬을 반환
+ * @param compareFn compareFn이 없는 경우 최초의 정렬을 반환
+ * @returns 
+ */
+const _revertDataInOrder = <V extends object>(
+    convertedData?: SortableTableDataType<V>,
+    key?: keyof V, // 
+    compareFn?: (a: any, b: any) => number, // will use original order
+) => {
 
     if (!convertedData || convertedData.size === 0){
-        setSortedData([]);
-        return;
-    }
-    
-    if (!key || !compareFn){
-        setSortedData(revertDataInOrder(convertedData));;
-        return;
-    }
-    
-    const targetColumn = convertedData.get(key);
-
-    if (targetColumn === undefined) {
-        console.error('Can not find key in data');
-        return;
+        return [];
     }
 
-    const sortedIndex = targetColumn
-        .map((v, i) => ({ v, i }))
-        .sort((a, b) => compareFn(a.v, b.v))
-        .map((sorted) => sorted.i);
+    const keys = [...convertedData.keys()];
+
+    const order = (()=>{
+        const targetColumn = convertedData.get(key || keys[0]);
+    
+        if (targetColumn === undefined) {
+            console.error('Can not find key in data');
+            return Array(convertedData.get(key || keys[0])?.length).fill(null).map((_,i) => i);
+        }
+
+        if (!compareFn){
+            return Array(targetColumn.length).fill(null).map((_,i) => i);
+        }
+    
+        const sortedIndex = targetColumn
+            .map((v, i) => ({ v, i }))
+            .sort((a, b) => compareFn(a.v, b.v))
+            .map((sorted) => sorted.i);
         
-    setSortedData(revertDataInOrder(convertedData, sortedIndex));
+            return sortedIndex;
+    })();
+        
+    const sortedData = order.map((index) => 
+        keys.map((key) => {
+            return { [key]: (convertedData.get(key)||[])[index] };
+        }).reduce((lhs, rhs) => {
+            return {...lhs, ...rhs}; 
+        }, {} as V)
+    )
 
+    return sortedData;
 }
 
 const useSortableTable = <V extends Object>(data: V[]) => {
     type K = keyof V;
 
-    const [convertedData, setConvertedData] = useState<SortableTableDataType<V> | undefined>(undefined);
-    const [sortedData, setSortedData] = useState<V[]>(() => data);
+    const [convertedData, setConvertedData] = useState<SortableTableDataType<V> | undefined>(_initalizeConvertedData(data));
     const [key, setKey] = useState<K>();
     const [compareFn, setCompareFn] = useState<(a: any, b: any) => number>();
 
     useEffect(() => {
-        const newConvertedData = _initalizeConvertedData(data);
-        setConvertedData(newConvertedData);
+
+        setConvertedData(_initalizeConvertedData(data));
         
-        _updateSortedData(newConvertedData, setSortedData, key, compareFn);
     }, [data]);
     
     /** validate params and pass key, compareFn */
@@ -117,20 +111,19 @@ const useSortableTable = <V extends Object>(data: V[]) => {
         setKey(key);
         setCompareFn(()=>compareFn);
         
-        _updateSortedData(convertedData, setSortedData, key, compareFn);
-
     }, [convertedData]);
 
     const initializeSort = useCallback(() => {
 
-        setConvertedData(_initalizeConvertedData(data));
-        setSortedData(data);
+        setKey(undefined);
+        setCompareFn(undefined);
+        
     }, [data]);
 
     const sortableTable = {
         sort,
         initializeSort,
-        sortedData
+        sortedData: _revertDataInOrder(convertedData, key, compareFn)
     };
 
     return sortableTable;

--- a/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
+++ b/packages/dataDisplay/useSortableTable/src/useSortableTable.tsx
@@ -4,12 +4,19 @@ type SortableTableDataType<V extends Object> = Map<keyof V, Array<V[keyof V]>>;
 
 const unique = <T,>(val: T, idx: number, arr: T[]) => arr.indexOf(val) === idx;
 
-const _initalizeConvertedData = <V extends Object,>(data: V[], keys: (keyof V)[]) => {
+const _initalizeConvertedData = <V extends Object,>(data: V[]) => {
+    type K = keyof V;
     const initTableData: SortableTableDataType<V> = new Map();
+    const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
+
+    if (keys.length === 0) {
+        return initTableData;
+    }
 
     keys.forEach((key) => {
         initTableData.set(key, []);
     });
+
 
     data.forEach((rowData) => {
         (Object.keys(rowData) as (keyof V)[]).forEach((key) => {
@@ -25,6 +32,59 @@ const _initalizeConvertedData = <V extends Object,>(data: V[], keys: (keyof V)[]
     return initTableData;
 }
 
+
+    /** sort data depends on convertedData, key, compareFn */
+const _updateSortedData = <V extends object>(
+    convertedData: SortableTableDataType<V>,
+    setSortedData: React.Dispatch<React.SetStateAction<V[]>>,
+    key?: keyof V,
+    compareFn?: (a: any, b: any) => number
+)=>{
+    
+    const revertDataInOrder = <V extends object>(convertedData: SortableTableDataType<V>, order?: number[]) => {
+
+        const keys = [...convertedData.keys()];
+            
+        const sortedIndex = order
+            ?? Array(convertedData.get(keys[0])?.length).fill(null).map((v,index) => index);
+
+        const sortedData = sortedIndex.map((index) => 
+            keys.map((key) => {
+                return { [key]: (convertedData.get(key)||[])[index] };
+            }).reduce((lhs, rhs) => {
+                return {...lhs, ...rhs}; 
+            }, {} as V)
+        )
+
+        return sortedData;
+    }
+
+    if (!convertedData || convertedData.size === 0){
+        setSortedData([]);
+        return;
+    }
+    
+    if (!key || !compareFn){
+        setSortedData(revertDataInOrder(convertedData));;
+        return;
+    }
+    
+    const targetColumn = convertedData.get(key);
+
+    if (targetColumn === undefined) {
+        console.error('Can not find key in data');
+        return;
+    }
+
+    const sortedIndex = targetColumn
+        .map((v, i) => ({ v, i }))
+        .sort((a, b) => compareFn(a.v, b.v))
+        .map((sorted) => sorted.i);
+        
+    setSortedData(revertDataInOrder(convertedData, sortedIndex));
+
+}
+
 const useSortableTable = <V extends Object>(data: V[]) => {
     type K = keyof V;
 
@@ -34,12 +94,10 @@ const useSortableTable = <V extends Object>(data: V[]) => {
     const [compareFn, setCompareFn] = useState<(a: any, b: any) => number>();
 
     useEffect(() => {
-        if (data.length === 0) {
-            return;
-        }
-        const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
-
-        setConvertedData(_initalizeConvertedData(data, keys));
+        const newConvertedData = _initalizeConvertedData(data);
+        setConvertedData(newConvertedData);
+        
+        _updateSortedData(newConvertedData, setSortedData, key, compareFn);
     }, [data]);
     
     /** validate params and pass key, compareFn */
@@ -52,65 +110,20 @@ const useSortableTable = <V extends Object>(data: V[]) => {
             throw new Error('sort parameters are not given');
         }
 
-        const keys = [...convertedData.keys()];
-
-        if (keys.length === 0) {
-            return;
-        }
-
-        const targetColumn = convertedData.get(key);
-
-        if (targetColumn === undefined) {
-            throw new Error('Can not find key in data');
+        if (convertedData.get(key) === undefined) {
+            throw new Error('Can not find key in data or data has no key');
         }
 
         setKey(key);
         setCompareFn(()=>compareFn);
+        
+        _updateSortedData(convertedData, setSortedData, key, compareFn);
 
     }, [convertedData]);
 
-    /** sort data depends on convertedData, key, compareFn */
-    useEffect(()=>{
-        if (!convertedData || !key || !compareFn){
-            return;
-        }
-        
-        const keys = [...convertedData.keys()];
-        
-        const targetColumn = convertedData.get(key);
-
-        if (targetColumn === undefined) {
-            setKey(undefined);
-            setCompareFn(undefined);
-            console.error('Can not find key in data');
-            return;
-        }
-
-        const sortedIndex = targetColumn
-            .map((v, i) => ({ v, i }))
-            .sort((a, b) => compareFn(a.v, b.v))
-            .map((sorted) => sorted.i);
-
-        const newSortedData = sortedIndex.map((index) =>
-            keys.map((key) => {
-                return { [key]: targetColumn[index] };
-            }).reduce((lhs, rhs) => {
-                return {...lhs, ...rhs}; 
-            }, {} as V)
-        );
-        
-        setSortedData(newSortedData);
-    
-    },[convertedData, key, compareFn])
-
     const initializeSort = useCallback(() => {
 
-        const keys = data.map(row => Object.keys(row) as K[]).flat().filter(unique);
-
-        if (keys.length === 0) {
-            return;
-        }
-        setConvertedData(_initalizeConvertedData(data, keys));
+        setConvertedData(_initalizeConvertedData(data));
         setSortedData(data);
     }, [data]);
 


### PR DESCRIPTION
```python
1. 왜 바꿨는지: PR의 목적을 적어주세요.
2. 영향 받을 수 있는 것들: 잠재적으로 이 PR에 의해 영향받을 수 있는 library, stylesheet, 동작방식 등을 적어주세요.
3. QA List: PR이 정상 작동한다면 기대되는 동작/나와선 안되는 동작을 체크리스트로 작성해주세요.
```

# 1. 왜 바꿨는지
- 데이터가 변경될 때 테이블의 정렬이 깨지는 문제를 해결합니다.
- sort 함수를 callback 과 effect로 분리합니다.
    - callback에서는 throwable한 것들을 처리하고 (key, compareFn) state를 업데이트함으로써 effect를 트리거 합니다.
    - effect에서는 (converted)data / key / compareFn에 따라 데이터를 정렬합니다.
        - '조용히 실패'하고, 정렬키의 문제인 경우 정렬키를 초기화합니다.
- memo로 구현되어 있던 keys를 매번 새로 계산하여 사용합니다. (single source of truth)

# 2. 영향 받을 수 있는 것들
-

# 3. QA List
- [ ] 
