### PR TITLE
[Feature][toast] useToastAlert과 컴포넌트로써 Toast를 분리합니다.

### DIFF
--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -2,7 +2,7 @@ import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { ReactNode } from 'react';
 
 declare const Toast: () => react_jsx_runtime.JSX.Element;
-declare const WithOutReoilToast: ({ message, timeout, iconType }: {
+declare const WithoutReoilToast: ({ message, timeout, iconType }: {
     message: React.ReactNode;
     timeout?: number;
     iconType?: "error" | "success" | "warning" | "info";
@@ -23,4 +23,4 @@ declare const useToastAlert: () => {
     toastAlert: toastAlertType;
 };
 
-export { Toast, WithOutReoilToast, type toastAlertType, useToastAlert };
+export { Toast, WithoutReoilToast, type toastAlertType, useToastAlert };

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -1,7 +1,12 @@
 import * as react_jsx_runtime from 'react/jsx-runtime';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 declare const Toast: () => react_jsx_runtime.JSX.Element;
+declare const WithOutReoilToast: ({ message, timeout, iconType }: {
+    message: React.ReactNode;
+    timeout?: number;
+    iconType?: "error" | "success" | "warning" | "info";
+}) => react_jsx_runtime.JSX.Element;
 
 declare const types: readonly ["success", "warning", "error", "info"];
 type toastIconTypes = typeof types[number];
@@ -18,4 +23,4 @@ declare const useToastAlert: () => {
     toastAlert: toastAlertType;
 };
 
-export { Toast, type toastAlertType, useToastAlert };
+export { Toast, WithOutReoilToast, type toastAlertType, useToastAlert };

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -23,4 +23,4 @@ declare const useToastAlert: () => {
     toastAlert: toastAlertType;
 };
 
-export { Toast, WithoutReoilToast, type toastAlertType, useToastAlert };
+export { Toast, WithoutReoilToast, type toastAlertType, type toastObjectType, useToastAlert };

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -1,26 +1,26 @@
 import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { ReactNode } from 'react';
 
-declare const Toast: () => react_jsx_runtime.JSX.Element;
-declare const WithoutReoilToast: ({ message, timeout, iconType }: {
+declare const GlobalToast: () => react_jsx_runtime.JSX.Element;
+declare const Toast: ({ message, timeout, iconType }: {
     message: React.ReactNode;
     timeout?: number;
     iconType?: "error" | "success" | "warning" | "info";
 }) => react_jsx_runtime.JSX.Element;
 
 declare const types: readonly ["success", "warning", "error", "info"];
-type toastIconTypes = typeof types[number];
-type toastObjectType = {
+type ToastIconTypes = typeof types[number];
+type ToastObjectType = {
     message: string | ReactNode;
     timeout?: number;
-    iconType?: toastIconTypes;
+    iconType?: ToastIconTypes;
 };
-type toastAlertType = {
-    (obj: toastObjectType): void;
-    (message: string, timeout?: number, iconType?: toastIconTypes): void;
+type ToastAlertType = {
+    (obj: ToastObjectType): void;
+    (message: string, timeout?: number, iconType?: ToastIconTypes): void;
 };
 declare const useToastAlert: () => {
-    toastAlert: toastAlertType;
+    toastAlert: ToastAlertType;
 };
 
-export { Toast, WithoutReoilToast, type toastAlertType, type toastObjectType, useToastAlert };
+export { GlobalToast, Toast, type ToastAlertType, type ToastObjectType, useToastAlert };

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -76,13 +76,13 @@ const RootToast = ({ message, timeout = 3000, iconType }) => {
                 ? jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx("img", { src: `https://static.webtoon.today/ddah/icon/icon_${iconType}.svg`, alt: iconType, width: 20, height: 20, style: { marginRight: 10 } }), message, jsxRuntime.jsx("div", { className: 'CheckButton', onClick: () => setAnimationState('FadeOut'), children: '확인' })] })
                 : message }) }));
 };
-const Toast = () => {
+const GlobalToast = () => {
     const toast = recoil.useRecoilValue(toastAlertAtom);
     const { message, timeout, iconType } = toast;
-    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message: message, timeout: timeout, iconType: iconType }) }));
+    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message, timeout, iconType }) }));
 };
-const WithoutReoilToast = RootToast;
+const Toast = RootToast;
 
+exports.GlobalToast = GlobalToast;
 exports.Toast = Toast;
-exports.WithoutReoilToast = WithoutReoilToast;
 exports.useToastAlert = useToastAlert;

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -81,8 +81,8 @@ const Toast = () => {
     const { message, timeout, iconType } = toast;
     return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message: message, timeout: timeout, iconType: iconType }) }));
 };
-const WithOutReoilToast = RootToast;
+const WithoutReoilToast = RootToast;
 
 exports.Toast = Toast;
-exports.WithOutReoilToast = WithOutReoilToast;
+exports.WithoutReoilToast = WithoutReoilToast;
 exports.useToastAlert = useToastAlert;

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -81,6 +81,8 @@ const Toast = () => {
     const { message, timeout, iconType } = toast;
     return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message: message, timeout: timeout, iconType: iconType }) }));
 };
+const WithOutReoilToast = RootToast;
 
 exports.Toast = Toast;
+exports.WithOutReoilToast = WithOutReoilToast;
 exports.useToastAlert = useToastAlert;

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -77,8 +77,7 @@ const RootToast = ({ message, timeout = 3000, iconType }) => {
                 : message }) }));
 };
 const GlobalToast = () => {
-    const toast = recoil.useRecoilValue(toastAlertAtom);
-    const { message, timeout, iconType } = toast;
+    const { message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
     return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message, timeout, iconType }) }));
 };
 const Toast = RootToast;

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var jsxRuntime = require('react/jsx-runtime');
-var React = require('react');
+var react = require('react');
 var recoil = require('recoil');
 
 const initialTimeout = 3000;
@@ -14,7 +14,7 @@ const toastAlertAtom = recoil.atom({
 });
 const useToastAlert = () => {
     const setToastAlertAtom = recoil.useSetRecoilState(toastAlertAtom);
-    const toastAlert = React.useCallback((messageOfParamsOrToastObject, timeoutOfParams, iconTypeOfParams) => {
+    const toastAlert = react.useCallback((messageOfParamsOrToastObject, timeoutOfParams, iconTypeOfParams) => {
         let message, timeout, iconType;
         if (typeof messageOfParamsOrToastObject === 'string') {
             message = messageOfParamsOrToastObject;
@@ -61,24 +61,25 @@ function styleInject(css, ref) {
 var css_248z = "@keyframes toast-in {\n  0% {\n    transform: translate3d(0, -100%, 0);\n    display: none;\n  }\n  1% {\n    transform: translate3d(0, -100%, 0);\n    display: block;\n  }\n  100% {\n    transform: translate3d(0, 0, 0);\n    display: block;\n  }\n}\n@keyframes toast-out {\n  0% {\n    display: block;\n    opacity: 1;\n    scale: 1;\n  }\n  99% {\n    display: block;\n    scale: 0.8;\n    opacity: 0;\n  }\n  100% {\n    scale: 0.8;\n    opacity: 0;\n    display: none;\n  }\n}\n.ToastBackgroundArea {\n  z-index: 2000;\n  font-size: 1rem;\n  position: fixed;\n  top: 24px;\n  text-align: center;\n  width: 100vw;\n  min-height: 50px;\n}\n.ToastBackgroundArea.FadeIn {\n  animation: toast-in 287ms linear forwards;\n}\n.ToastBackgroundArea.FadeOut {\n  animation: toast-out 287ms linear forwards;\n}\n.ToastBackgroundArea.Close {\n  display: none;\n}\n.ToastBackgroundArea .ToastBox {\n  display: inline-flex;\n  justify-content: center;\n  padding: 15px 22px;\n  margin: 0 auto;\n  border-radius: 12px;\n  background: rgb(51, 51, 53);\n  box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.3), 0px 3px 12px 3px rgba(0, 0, 0, 0.1);\n  color: rgb(255, 255, 255);\n  white-space: pre-line;\n  word-break: keep-all;\n  text-align: start;\n  max-width: 600px;\n}\n@media (max-width: 700px) {\n  .ToastBackgroundArea .ToastBox {\n    max-width: calc(100% - 62px);\n  }\n}\n.ToastBackgroundArea .ToastBox.IconToast {\n  align-items: flex-start;\n  gap: 10px;\n}\n.ToastBackgroundArea .ToastBox .CheckButton {\n  color: rgb(61, 106, 255);\n  margin-left: 10px;\n  cursor: pointer;\n  align-self: flex-end;\n}";
 styleInject(css_248z);
 
-const Toast = () => {
-    const toast = recoil.useRecoilValue(toastAlertAtom);
-    const [animationState, setAnimationState] = React.useState('Close');
-    React.useEffect(() => {
-        if (!toast.message) {
-            return;
-        }
+const RootToast = ({ message, timeout = 3000, iconType }) => {
+    const [animationState, setAnimationState] = react.useState('Close');
+    react.useEffect(() => {
         setAnimationState('FadeIn');
         const timer = setTimeout(() => {
             setAnimationState('FadeOut');
-        }, toast.timeout);
+        }, timeout);
         return () => {
             clearTimeout(timer);
         };
-    }, [toast]);
-    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${toast && toast.iconType ? "IconToast" : ""}`, children: toast && toast.iconType
-                    ? jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx("img", { src: `https://static.webtoon.today/ddah/icon/icon_${toast.iconType}.svg`, alt: toast.iconType, width: 20, height: 20, style: { marginRight: 10 } }), toast.message, jsxRuntime.jsx("div", { className: 'CheckButton', onClick: () => setAnimationState('FadeOut'), children: '확인' })] })
-                    : toast.message }) }) }));
+    }, [message, timeout]);
+    return (jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${iconType ? "IconToast" : ""}`, children: iconType
+                ? jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx("img", { src: `https://static.webtoon.today/ddah/icon/icon_${iconType}.svg`, alt: iconType, width: 20, height: 20, style: { marginRight: 10 } }), message, jsxRuntime.jsx("div", { className: 'CheckButton', onClick: () => setAnimationState('FadeOut'), children: '확인' })] })
+                : message }) }));
+};
+const Toast = () => {
+    const toast = recoil.useRecoilValue(toastAlertAtom);
+    const { message, timeout, iconType } = toast;
+    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message: message, timeout: timeout, iconType: iconType }) }));
 };
 
 exports.Toast = Toast;

--- a/dist/useSortableTable/index.js
+++ b/dist/useSortableTable/index.js
@@ -5,7 +5,7 @@ var react = require('react');
 const unique = (val, idx, arr) => arr.indexOf(val) === idx;
 const _initalizeConvertedData = (data) => {
     const initTableData = new Map();
-    const keys = data.map(row => Object.keys(row)).flat().filter(unique);
+    const keys = data.flatMap(row => Object.keys(row)).filter(unique);
     if (keys.length === 0) {
         return initTableData;
     }

--- a/packages/feedback/Toast/src/Recoil/Toast.ts
+++ b/packages/feedback/Toast/src/Recoil/Toast.ts
@@ -4,11 +4,12 @@ import { atom, useSetRecoilState } from "recoil";
 const types = ["success", "warning", "error", "info"] as const
 export type toastIconTypes = typeof types[number];
 
-type toastObjectType = {
+export type toastObjectType = {
     message: string | ReactNode,
     timeout?: number,
     iconType?: toastIconTypes
 }
+
 export type toastAlertType = {
     (obj: toastObjectType): void;
     (message: string, timeout?: number, iconType?: toastIconTypes): void;

--- a/packages/feedback/Toast/src/Recoil/Toast.ts
+++ b/packages/feedback/Toast/src/Recoil/Toast.ts
@@ -2,21 +2,21 @@ import { ReactNode, useCallback } from "react";
 import { atom, useSetRecoilState } from "recoil";
 
 const types = ["success", "warning", "error", "info"] as const
-export type toastIconTypes = typeof types[number];
+export type ToastIconTypes = typeof types[number];
 
-export type toastObjectType = {
+export type ToastObjectType = {
     message: string | ReactNode,
     timeout?: number,
-    iconType?: toastIconTypes
+    iconType?: ToastIconTypes
 }
 
-export type toastAlertType = {
-    (obj: toastObjectType): void;
-    (message: string, timeout?: number, iconType?: toastIconTypes): void;
+export type ToastAlertType = {
+    (obj: ToastObjectType): void;
+    (message: string, timeout?: number, iconType?: ToastIconTypes): void;
 }
 
 const initialTimeout = 3000;
-const toastDefault: toastObjectType = {
+const toastDefault: ToastObjectType = {
     message: '', timeout: 0,
 }
 export const toastAlertAtom = atom({
@@ -27,10 +27,10 @@ export const toastAlertAtom = atom({
 export const useToastAlert = () => {
     const setToastAlertAtom = useSetRecoilState(toastAlertAtom);
 
-    const toastAlert: toastAlertType = useCallback( (
-        messageOfParamsOrToastObject: string | toastObjectType,
+    const toastAlert: ToastAlertType = useCallback( (
+        messageOfParamsOrToastObject: string | ToastObjectType,
         timeoutOfParams?: number,
-        iconTypeOfParams?: toastIconTypes
+        iconTypeOfParams?: ToastIconTypes
     ): void => {
         let message, timeout, iconType;
 

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -2,16 +2,16 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 
-import { WithOutReoilToast } from './Toast';
+import { WithoutReoilToast } from './Toast';
 
 const meta = {
     title: 'feadback/Toast',
-    component: WithOutReoilToast,
+    component: WithoutReoilToast,
     parameters: {
         layout: 'centered',
     },
     tags: ['autodocs'],
-} satisfies Meta<typeof WithOutReoilToast>;
+} satisfies Meta<typeof WithoutReoilToast>;
 
 export default meta;
 
@@ -22,7 +22,7 @@ export const Default = {
         return (
             <div>
                 content
-                <WithOutReoilToast message={'hello'} />
+                <WithoutReoilToast message={'hello'} />
             </div>
         )
     }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -2,16 +2,16 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 
-import { WithoutReoilToast } from './Toast';
+import { Toast } from './Toast';
 
 const meta = {
     title: 'feadback/Toast',
-    component: WithoutReoilToast,
+    component: Toast,
     parameters: {
         layout: 'centered',
     },
     tags: ['autodocs'],
-} satisfies Meta<typeof WithoutReoilToast>;
+} satisfies Meta<typeof Toast>;
 
 export default meta;
 
@@ -22,7 +22,7 @@ export const Default = {
         return (
             <div>
                 content
-                <WithoutReoilToast message={'hello'} />
+                <Toast message={'hello'} />
             </div>
         )
     }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import React from 'react';
+
+import { WithOutReoilToast } from './Toast';
+
+const meta = {
+    title: 'feadback/Toast',
+    component: WithOutReoilToast,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+} satisfies Meta<typeof WithOutReoilToast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+    render: () => {
+        return (
+            <div>
+                content
+                <WithOutReoilToast message={'hello'} />
+            </div>
+        )
+    }
+}

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -1,44 +1,53 @@
-import React from 'react';
-import { toastAlertAtom } from './Recoil/Toast';
+import React, { useEffect, useState } from 'react';
+
 import { RecoilRoot, useRecoilValue } from 'recoil';
+
+import { toastAlertAtom } from './Recoil/Toast';
 
 import './Toast.scss';
 
-export const Toast = () => {
-    const toast = useRecoilValue(toastAlertAtom);
-    const [animationState, setAnimationState] = React.useState<'FadeIn' | 'FadeOut' | 'Close'>('Close');
+const RootToast = ({ message, timeout = 3000, iconType } : { message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" }) => {
+    const [animationState, setAnimationState] = useState<'FadeIn' | 'FadeOut' | 'Close'>('Close');
 
-    React.useEffect(()=>{
-        if (!toast.message) {
-            return;
-        }
-
+    useEffect(()=>{
         setAnimationState('FadeIn');
 
         const timer = setTimeout(()=>{
             setAnimationState('FadeOut');
-        }, toast.timeout);
+        }, timeout);
 
         return ()=>{
             clearTimeout(timer);
         }
-    },[toast])
+    },[message, timeout]);
+
+    return (
+        <div className={`ToastBackgroundArea ${animationState}`} >
+            <div className={`ToastBox ${ iconType ? "IconToast":""}`} >
+                {iconType
+                    ?<>
+                        <img src={`https://static.webtoon.today/ddah/icon/icon_${iconType}.svg`} alt={iconType} width={20} height={20} style={{marginRight: 10}} />
+                        {message}
+                        <div className={'CheckButton'} onClick={()=>setAnimationState('FadeOut')} >
+                            {'확인'}
+                        </div>
+                    </>
+                    :message}
+            </div>
+        </div>
+    )
+}
+
+export const Toast = () => {
+    const toast = useRecoilValue(toastAlertAtom);
+
+    const { message, timeout, iconType } = toast;
 
     return (
         <RecoilRoot>
-            <div className={`ToastBackgroundArea ${animationState}`} >
-                <div className={`ToastBox ${toast && toast.iconType?"IconToast":""}`} >
-                    {toast && toast.iconType
-                        ?<>
-                            <img src={`https://static.webtoon.today/ddah/icon/icon_${toast.iconType}.svg`} alt={toast.iconType} width={20} height={20} style={{marginRight: 10}} />
-                            {toast.message}
-                            <div className={'CheckButton'} onClick={()=>setAnimationState('FadeOut')} >
-                                {'확인'}
-                            </div>
-                        </>
-                        :toast.message}
-                </div>
-            </div>
+            <RootToast message={message} timeout={timeout} iconType={iconType} />
         </RecoilRoot>
-    )
+    );
 }
+
+export const WithOutReoilToast = RootToast;

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -39,9 +39,7 @@ const RootToast = ({ message, timeout = 3000, iconType } : { message: React.Reac
 }
 
 export const GlobalToast = () => {
-    const toast = useRecoilValue(toastAlertAtom);
-
-    const { message, timeout, iconType } = toast;
+    const { message, timeout, iconType } = useRecoilValue(toastAlertAtom);
 
     return (
         <RecoilRoot>

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -50,4 +50,4 @@ export const Toast = () => {
     );
 }
 
-export const WithOutReoilToast = RootToast;
+export const WithoutReoilToast = RootToast;

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -38,16 +38,16 @@ const RootToast = ({ message, timeout = 3000, iconType } : { message: React.Reac
     )
 }
 
-export const Toast = () => {
+export const GlobalToast = () => {
     const toast = useRecoilValue(toastAlertAtom);
 
     const { message, timeout, iconType } = toast;
 
     return (
         <RecoilRoot>
-            <RootToast message={message} timeout={timeout} iconType={iconType} />
+            <RootToast {...{message, timeout, iconType}} />
         </RecoilRoot>
     );
 }
 
-export const WithoutReoilToast = RootToast;
+export const Toast = RootToast;

--- a/packages/feedback/Toast/src/main.ts
+++ b/packages/feedback/Toast/src/main.ts
@@ -1,3 +1,3 @@
-export { Toast, WithoutReoilToast } from "./Toast";
+export { GlobalToast, Toast } from "./Toast";
 export { useToastAlert } from "./Recoil/Toast";
-export type { toastAlertType, toastObjectType } from "./Recoil/Toast";
+export type { ToastAlertType, ToastObjectType } from "./Recoil/Toast";

--- a/packages/feedback/Toast/src/main.ts
+++ b/packages/feedback/Toast/src/main.ts
@@ -1,3 +1,3 @@
-export { Toast } from "./Toast";
+export { Toast, WithOutReoilToast } from "./Toast";
 export { useToastAlert } from "./Recoil/Toast";
 export type { toastAlertType } from "./Recoil/Toast";

--- a/packages/feedback/Toast/src/main.ts
+++ b/packages/feedback/Toast/src/main.ts
@@ -1,3 +1,3 @@
-export { Toast, WithOutReoilToast } from "./Toast";
+export { Toast, WithoutReoilToast } from "./Toast";
 export { useToastAlert } from "./Recoil/Toast";
 export type { toastAlertType } from "./Recoil/Toast";

--- a/packages/feedback/Toast/src/main.ts
+++ b/packages/feedback/Toast/src/main.ts
@@ -1,3 +1,3 @@
 export { Toast, WithoutReoilToast } from "./Toast";
 export { useToastAlert } from "./Recoil/Toast";
-export type { toastAlertType } from "./Recoil/Toast";
+export type { toastAlertType, toastObjectType } from "./Recoil/Toast";


### PR DESCRIPTION
```python
1. 왜 바꿨는지: PR의 목적을 적어주세요.
2. 영향 받을 수 있는 것들: 잠재적으로 이 PR에 의해 영향받을 수 있는 library, stylesheet, 동작방식 등을 적어주세요.
3. QA List: PR이 정상 작동한다면 기대되는 동작/나와선 안되는 동작을 체크리스트로 작성해주세요.
```

# 1. 왜 바꿨는지
- `useToastAlert`을 통한 훅 호출 뿐만 아니라 컴포넌트 렌더링을 지원합니다.
- 홀로 사용할 수 있는 토스트 컴포넌트를 위해 기본의 `Toast`를 `GlobalToast`로 이름을 바꿉니다.
- `Toast`를 일반적인 react component 사용하듯이 렌더링할 수 있습니다.
- 타입 관련된 변수명을 파스칼 케이스로 바꿉니다.
- 스토리북 코드에서 리코일 사용에 이슈가 있어, 기본 토스트를 이용한 렌더링을 테스트합니다.

# 2. 영향 받을 수 있는 것들
-

# 3. QA List
- [ ] 
