### PR TITLE
[Bugfix][Toast] 메시지를 변경하지 않고 toastAlert 함수를 두 번 이상 호출 시 토스트가 보이지 않는 문제 수정합니다.

### DIFF
--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -2,7 +2,9 @@ import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { ReactNode } from 'react';
 
 declare const GlobalToast: () => react_jsx_runtime.JSX.Element;
-declare const Toast: ({ message, timeout, iconType }: {
+declare const Toast: ({ show, onClose, message, timeout, iconType }: {
+    show: boolean;
+    onClose?: () => void;
     message: React.ReactNode;
     timeout?: number;
     iconType?: "error" | "success" | "warning" | "info";

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -2,8 +2,8 @@ import * as react_jsx_runtime from 'react/jsx-runtime';
 import React, { ReactNode } from 'react';
 
 declare const GlobalToast: () => react_jsx_runtime.JSX.Element;
-declare const Toast: ({ show, onClose, message, timeout, iconType }: {
-    show: boolean;
+declare const Toast: ({ open, onClose, message, timeout, iconType }: {
+    open: boolean;
     onClose?: () => void;
     message: React.ReactNode;
     timeout?: number;

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 declare const GlobalToast: () => react_jsx_runtime.JSX.Element;
 declare const Toast: ({ open, onClose, message, timeout, iconType }: {
     open: boolean;
-    onClose?: () => void;
+    onClose?: (e?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     message: React.ReactNode;
     timeout?: number;
     iconType?: "error" | "success" | "warning" | "info" | undefined;

--- a/dist/Toast/index.d.ts
+++ b/dist/Toast/index.d.ts
@@ -7,7 +7,7 @@ declare const Toast: ({ open, onClose, message, timeout, iconType }: {
     onClose?: () => void;
     message: React.ReactNode;
     timeout?: number;
-    iconType?: "error" | "success" | "warning" | "info";
+    iconType?: "error" | "success" | "warning" | "info" | undefined;
 }) => react_jsx_runtime.JSX.Element | null;
 
 declare const types: readonly ["success", "warning", "error", "info"];

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -86,7 +86,8 @@ const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
             clearTimeout(closeTimer.current);
         };
     }, []);
-    if (!message) {
+    if (!message ||
+        JSON.stringify(message) === JSON.stringify({})) {
         return null;
     }
     return (jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${iconType ? "IconToast" : ""}`, children: iconType

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -6,7 +6,7 @@ var recoil = require('recoil');
 
 const initialTimeout = 3000;
 const toastDefault = {
-    message: '', timeout: 0,
+    message: '', timeout: 0, show: false
 };
 const toastAlertAtom = recoil.atom({
     key: "toastAlertKey",
@@ -26,7 +26,7 @@ const useToastAlert = () => {
             timeout = messageOfParamsOrToastObject.timeout;
             iconType = messageOfParamsOrToastObject.iconType;
         }
-        setToastAlertAtom({ message, timeout: timeout || initialTimeout, iconType });
+        setToastAlertAtom({ show: true, message, timeout: timeout || initialTimeout, iconType });
     }, [setToastAlertAtom]);
     return ({ toastAlert });
 };
@@ -58,30 +58,45 @@ function styleInject(css, ref) {
   }
 }
 
-var css_248z = "@keyframes toast-in {\n  0% {\n    transform: translate3d(0, -100%, 0);\n    display: none;\n  }\n  1% {\n    transform: translate3d(0, -100%, 0);\n    display: block;\n  }\n  100% {\n    transform: translate3d(0, 0, 0);\n    display: block;\n  }\n}\n@keyframes toast-out {\n  0% {\n    display: block;\n    opacity: 1;\n    scale: 1;\n  }\n  99% {\n    display: block;\n    scale: 0.8;\n    opacity: 0;\n  }\n  100% {\n    scale: 0.8;\n    opacity: 0;\n    display: none;\n  }\n}\n.ToastBackgroundArea {\n  z-index: 2000;\n  font-size: 1rem;\n  position: fixed;\n  top: 24px;\n  text-align: center;\n  width: 100vw;\n  min-height: 50px;\n}\n.ToastBackgroundArea.FadeIn {\n  animation: toast-in 287ms linear forwards;\n}\n.ToastBackgroundArea.FadeOut {\n  animation: toast-out 287ms linear forwards;\n}\n.ToastBackgroundArea.Close {\n  display: none;\n}\n.ToastBackgroundArea .ToastBox {\n  display: inline-flex;\n  justify-content: center;\n  padding: 15px 22px;\n  margin: 0 auto;\n  border-radius: 12px;\n  background: rgb(51, 51, 53);\n  box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.3), 0px 3px 12px 3px rgba(0, 0, 0, 0.1);\n  color: rgb(255, 255, 255);\n  white-space: pre-line;\n  word-break: keep-all;\n  text-align: start;\n  max-width: 600px;\n}\n@media (max-width: 700px) {\n  .ToastBackgroundArea .ToastBox {\n    max-width: calc(100% - 62px);\n  }\n}\n.ToastBackgroundArea .ToastBox.IconToast {\n  align-items: flex-start;\n  gap: 10px;\n}\n.ToastBackgroundArea .ToastBox .CheckButton {\n  color: rgb(61, 106, 255);\n  margin-left: 10px;\n  cursor: pointer;\n  align-self: flex-end;\n}";
+var css_248z = "@keyframes toast-in {\n  0% {\n    transform: translate3d(0, -100%, 0);\n    display: none;\n  }\n  1% {\n    transform: translate3d(0, -100%, 0);\n    display: block;\n  }\n  100% {\n    transform: translate3d(0, 0, 0);\n    display: block;\n  }\n}\n@keyframes toast-out {\n  0% {\n    display: block;\n    opacity: 1;\n    scale: 1;\n  }\n  99% {\n    display: block;\n    scale: 0.8;\n    opacity: 0;\n  }\n  100% {\n    scale: 0.8;\n    opacity: 0;\n    display: none;\n  }\n}\n.ToastBackgroundArea {\n  position: fixed;\n  top: 24px;\n  right: 0;\n  left: 0;\n  z-index: 2000;\n  min-height: 50px;\n  text-align: center;\n  font-size: 1rem;\n}\n.ToastBackgroundArea.FadeIn {\n  animation: toast-in 287ms linear forwards;\n}\n.ToastBackgroundArea.FadeOut {\n  animation: toast-out 287ms linear forwards;\n}\n.ToastBackgroundArea.Close {\n  display: none;\n}\n.ToastBackgroundArea .ToastBox {\n  display: inline-flex;\n  justify-content: center;\n  padding: 15px 22px;\n  margin: 0 auto;\n  border-radius: 12px;\n  background: rgb(51, 51, 53);\n  box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.3), 0px 3px 12px 3px rgba(0, 0, 0, 0.1);\n  color: rgb(255, 255, 255);\n  white-space: pre-line;\n  word-break: keep-all;\n  text-align: start;\n  max-width: 600px;\n}\n@media (max-width: 700px) {\n  .ToastBackgroundArea .ToastBox {\n    max-width: calc(100% - 62px);\n  }\n}\n.ToastBackgroundArea .ToastBox.IconToast {\n  align-items: flex-start;\n  gap: 10px;\n}\n.ToastBackgroundArea .ToastBox .CheckButton {\n  color: rgb(61, 106, 255);\n  margin-left: 10px;\n  cursor: pointer;\n  align-self: flex-end;\n}";
 styleInject(css_248z);
 
-const RootToast = ({ message, timeout = 3000, iconType }) => {
+const ANIMATION_DURATION = 287;
+const RootToast = ({ show, onClose, message, timeout = 3000, iconType }) => {
     const [animationState, setAnimationState] = react.useState('Close');
+    const closeTimer = react.useRef(undefined);
+    const handleClose = react.useCallback(() => {
+        setAnimationState('FadeOut');
+        if (!!onClose) {
+            closeTimer.current = setTimeout(onClose, ANIMATION_DURATION);
+        }
+    }, [onClose]);
     react.useEffect(() => {
+        if (!show) {
+            return;
+        }
         setAnimationState('FadeIn');
-        const timer = setTimeout(() => {
-            setAnimationState('FadeOut');
-        }, timeout);
+        const timer = setTimeout(handleClose, timeout);
         return () => {
             clearTimeout(timer);
         };
-    }, [message, timeout]);
+    }, [message, timeout, show]);
+    react.useEffect(() => {
+        return () => {
+            clearTimeout(closeTimer.current);
+        };
+    }, []);
     if (!message) {
         return null;
     }
     return (jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${iconType ? "IconToast" : ""}`, children: iconType
-                ? jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx("img", { src: `https://static.webtoon.today/ddah/icon/icon_${iconType}.svg`, alt: iconType, width: 20, height: 20, style: { marginRight: 10 } }), message, jsxRuntime.jsx("div", { className: 'CheckButton', onClick: () => setAnimationState('FadeOut'), children: '확인' })] })
+                ? jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx("img", { src: `https://static.webtoon.today/ddah/icon/icon_${iconType}.svg`, alt: iconType, width: 20, height: 20, style: { marginRight: 10 } }), message, jsxRuntime.jsx("div", { className: 'CheckButton', onClick: handleClose, children: '확인' })] })
                 : message }) }));
 };
 const GlobalToast = () => {
-    const { message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
-    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { message, timeout, iconType }) }));
+    const { show, message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
+    const setToastAlertAtom = recoil.useSetRecoilState(toastAlertAtom);
+    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { show: show, onClose: () => setToastAlertAtom({ show: false, message: '' }), message, timeout, iconType }) }));
 };
 const Toast = RootToast;
 

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -6,7 +6,7 @@ var recoil = require('recoil');
 
 const initialTimeout = 3000;
 const toastDefault = {
-    message: '', timeout: 0, show: false
+    message: '', timeout: 0, open: false
 };
 const toastAlertAtom = recoil.atom({
     key: "toastAlertKey",
@@ -26,7 +26,7 @@ const useToastAlert = () => {
             timeout = messageOfParamsOrToastObject.timeout;
             iconType = messageOfParamsOrToastObject.iconType;
         }
-        setToastAlertAtom({ show: true, message, timeout: timeout || initialTimeout, iconType });
+        setToastAlertAtom({ open: true, message, timeout: timeout || initialTimeout, iconType });
     }, [setToastAlertAtom]);
     return ({ toastAlert });
 };
@@ -62,7 +62,7 @@ var css_248z = "@keyframes toast-in {\n  0% {\n    transform: translate3d(0, -10
 styleInject(css_248z);
 
 const ANIMATION_DURATION = 287;
-const RootToast = ({ show, onClose, message, timeout = 3000, iconType }) => {
+const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
     const [animationState, setAnimationState] = react.useState('Close');
     const closeTimer = react.useRef(undefined);
     const handleClose = react.useCallback(() => {
@@ -72,7 +72,7 @@ const RootToast = ({ show, onClose, message, timeout = 3000, iconType }) => {
         }
     }, [onClose]);
     react.useEffect(() => {
-        if (!show) {
+        if (!open) {
             return;
         }
         setAnimationState('FadeIn');
@@ -80,7 +80,7 @@ const RootToast = ({ show, onClose, message, timeout = 3000, iconType }) => {
         return () => {
             clearTimeout(timer);
         };
-    }, [message, timeout, show]);
+    }, [message, timeout, open]);
     react.useEffect(() => {
         return () => {
             clearTimeout(closeTimer.current);
@@ -94,9 +94,9 @@ const RootToast = ({ show, onClose, message, timeout = 3000, iconType }) => {
                 : message }) }));
 };
 const GlobalToast = () => {
-    const { show, message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
+    const { open, message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
     const setToastAlertAtom = recoil.useSetRecoilState(toastAlertAtom);
-    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { show: show, onClose: () => setToastAlertAtom({ show: false, message: '' }), message, timeout, iconType }) }));
+    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { open: open, onClose: () => setToastAlertAtom({ open: false, message: '' }), message, timeout, iconType }) }));
 };
 const Toast = RootToast;
 

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -65,10 +65,10 @@ const ANIMATION_DURATION = 287;
 const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
     const [animationState, setAnimationState] = react.useState('Close');
     const closeTimer = react.useRef(undefined);
-    const handleClose = react.useCallback(() => {
+    const handleClose = react.useCallback((e) => {
         setAnimationState('FadeOut');
         if (!!onClose) {
-            closeTimer.current = setTimeout(onClose, ANIMATION_DURATION);
+            closeTimer.current = setTimeout(() => onClose(e), ANIMATION_DURATION);
         }
     }, [onClose]);
     react.useEffect(() => {
@@ -80,14 +80,13 @@ const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
         return () => {
             clearTimeout(timer);
         };
-    }, [message, timeout, open]);
+    }, [open, timeout, handleClose]);
     react.useEffect(() => {
         return () => {
             clearTimeout(closeTimer.current);
         };
     }, []);
-    if (!message ||
-        JSON.stringify(message) === JSON.stringify({})) {
+    if (!message || JSON.stringify(message) === JSON.stringify({})) {
         return null;
     }
     return (jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${iconType ? "IconToast" : ""}`, children: iconType
@@ -97,7 +96,7 @@ const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
 const GlobalToast = () => {
     const { open, message, timeout, iconType } = recoil.useRecoilValue(toastAlertAtom);
     const setToastAlertAtom = recoil.useSetRecoilState(toastAlertAtom);
-    return (jsxRuntime.jsx(recoil.RecoilRoot, { children: jsxRuntime.jsx(RootToast, { open: open, onClose: () => setToastAlertAtom({ open: false, message: '' }), message, timeout, iconType }) }));
+    return (jsxRuntime.jsx(RootToast, { open: open, onClose: () => setToastAlertAtom({ open: false, message: '' }), message, timeout, iconType }));
 };
 const Toast = RootToast;
 

--- a/dist/Toast/index.js
+++ b/dist/Toast/index.js
@@ -86,7 +86,7 @@ const RootToast = ({ open, onClose, message, timeout = 3000, iconType }) => {
             clearTimeout(closeTimer.current);
         };
     }, []);
-    if (!message || JSON.stringify(message) === JSON.stringify({})) {
+    if (!message) {
         return null;
     }
     return (jsxRuntime.jsx("div", { className: `ToastBackgroundArea ${animationState}`, children: jsxRuntime.jsx("div", { className: `ToastBox ${iconType ? "IconToast" : ""}`, children: iconType

--- a/packages/feedback/Toast/src/Recoil/Toast.ts
+++ b/packages/feedback/Toast/src/Recoil/Toast.ts
@@ -16,8 +16,8 @@ export type ToastAlertType = {
 }
 
 const initialTimeout = 3000;
-const toastDefault: ToastObjectType = {
-    message: '', timeout: 0,
+const toastDefault: ToastObjectType & { show: boolean } = {
+    message: '', timeout: 0, show: false
 }
 export const toastAlertAtom = atom({
     key: "toastAlertKey",
@@ -44,7 +44,7 @@ export const useToastAlert = () => {
             iconType = messageOfParamsOrToastObject.iconType;
         }
 
-        setToastAlertAtom({message, timeout: timeout || initialTimeout, iconType});
+        setToastAlertAtom({show: true, message, timeout: timeout || initialTimeout, iconType});
     },[setToastAlertAtom])
 
     return ({ toastAlert })

--- a/packages/feedback/Toast/src/Recoil/Toast.ts
+++ b/packages/feedback/Toast/src/Recoil/Toast.ts
@@ -16,8 +16,8 @@ export type ToastAlertType = {
 }
 
 const initialTimeout = 3000;
-const toastDefault: ToastObjectType & { show: boolean } = {
-    message: '', timeout: 0, show: false
+const toastDefault: ToastObjectType & { open: boolean } = {
+    message: '', timeout: 0, open: false
 }
 export const toastAlertAtom = atom({
     key: "toastAlertKey",
@@ -44,7 +44,7 @@ export const useToastAlert = () => {
             iconType = messageOfParamsOrToastObject.iconType;
         }
 
-        setToastAlertAtom({show: true, message, timeout: timeout || initialTimeout, iconType});
+        setToastAlertAtom({open: true, message, timeout: timeout || initialTimeout, iconType});
     },[setToastAlertAtom])
 
     return ({ toastAlert })

--- a/packages/feedback/Toast/src/Recoil/Toast.ts
+++ b/packages/feedback/Toast/src/Recoil/Toast.ts
@@ -45,7 +45,7 @@ export const useToastAlert = () => {
         }
 
         setToastAlertAtom({open: true, message, timeout: timeout || initialTimeout, iconType});
-    },[setToastAlertAtom])
+    },[setToastAlertAtom]);
 
     return ({ toastAlert })
 }

--- a/packages/feedback/Toast/src/Toast.scss
+++ b/packages/feedback/Toast/src/Toast.scss
@@ -32,13 +32,16 @@
 }
 
 .ToastBackgroundArea{
-    z-index: 2000;
-    font-size: 1rem;
     position: fixed;
     top: 24px; 
-    text-align: center;
-    width: 100vw; 
+    right: 0;
+    left: 0; 
+    z-index: 2000;
+    
     min-height: 50px;
+    
+    text-align: center;
+    font-size: 1rem;
     
     &.FadeIn  { animation: toast-in  287ms linear forwards; }
     &.FadeOut { animation: toast-out 287ms linear forwards; }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-import { Toast } from './Toast';
+import { GlobalToast, Toast } from './Toast';
+import { useToastAlert } from './Recoil/Toast';
+import { RecoilRoot } from 'recoil';
 
 const meta = {
     title: 'feedback/Toast',
@@ -17,13 +19,48 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const Default= {
     render: () => {
+        const [show, setShow] = useState(false);
+        const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+        useEffect(() => {
+            if (show) {
+                timer.current = setTimeout(() => {
+                    setShow(false);
+                }, 3000);
+            }
+            return () => {
+                clearTimeout(timer.current);
+            };
+        }, [show]);
+
         return (
             <div>
-                content
-                <Toast message={'hello'} />
+                <button onClick={() => setShow(true)} disabled={show}>toast</button>
+                <Toast show={show} message={'hello'} />
             </div>
+        )
+    }
+}
+
+const ToastAlertHookContainer = () => {
+    const { toastAlert } = useToastAlert();
+
+    return (
+        <div>
+            <button onClick={() => toastAlert("hello")}>useToastAlertHook</button>
+            <GlobalToast />
+        </div>
+    )
+}
+
+export const useToastAlertHook = {
+    render: () => {
+        return (
+            <RecoilRoot>
+                <ToastAlertHookContainer />
+            </RecoilRoot>
         )
     }
 }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -21,12 +21,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default= {
     render: () => {
-        const [show, setShow] = useState(false);
+        const [open, setOpen] = useState(false);
 
         return (
             <div>
-                <button onClick={() => setShow(true)}>toast</button>
-                <Toast show={show} message={'hello'} onClose={() => setShow(false)}/>
+                <button onClick={() => setOpen(true)}>toast</button>
+                <Toast open={open} message={'hello'} onClose={() => setOpen(false)}/>
             </div>
         )
     }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -19,7 +19,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default= {
+export const Default = {
     render: (args) => {
         const [open, setOpen] = useState(false);
 
@@ -38,7 +38,6 @@ const ToastAlertHookContainer = (args) => {
     return (
         <div>
             <button onClick={() => toastAlert({ message: args.message || "hello", timeout: args.timeout, iconType: args.iconType })}>useToastAlertHook</button>
-            <GlobalToast />
         </div>
     )
 }
@@ -48,6 +47,7 @@ export const useToastAlertHook = {
         return (
             <RecoilRoot>
                 <ToastAlertHookContainer {...args}/>
+                <GlobalToast />
             </RecoilRoot>
         )
     }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 
-import { GlobalToast, Toast } from './Toast';
-import { useToastAlert } from './Recoil/Toast';
 import { RecoilRoot } from 'recoil';
+import { useToastAlert } from './Recoil/Toast';
+import { GlobalToast, Toast } from './Toast';
 
 const meta = {
     title: 'feedback/Toast',
@@ -20,34 +20,34 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default= {
-    render: () => {
+    render: (args) => {
         const [open, setOpen] = useState(false);
 
         return (
             <div>
                 <button onClick={() => setOpen(true)}>toast</button>
-                <Toast open={open} message={'hello'} onClose={() => setOpen(false)}/>
+                <Toast open={open} onClose={() => setOpen(false)} message={args.message || 'hello'} iconType={args.iconType} timeout={args.timeout}/>
             </div>
         )
     }
 }
 
-const ToastAlertHookContainer = () => {
+const ToastAlertHookContainer = (args) => {
     const { toastAlert } = useToastAlert();
 
     return (
         <div>
-            <button onClick={() => toastAlert("hello")}>useToastAlertHook</button>
+            <button onClick={() => toastAlert({ message: args.message || "hello", timeout: args.timeout, iconType: args.iconType })}>useToastAlertHook</button>
             <GlobalToast />
         </div>
     )
 }
 
 export const useToastAlertHook = {
-    render: () => {
+    render: (args) => {
         return (
             <RecoilRoot>
-                <ToastAlertHookContainer />
+                <ToastAlertHookContainer {...args}/>
             </RecoilRoot>
         )
     }

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -36,12 +36,13 @@ const ToastAlertHookContainer = (args) => {
     const { toastAlert } = useToastAlert();
 
     return (
-        <div>
-            <button onClick={() => toastAlert({ message: args.message || "hello", timeout: args.timeout, iconType: args.iconType })}>useToastAlertHook</button>
-        </div>
+        <button onClick={() => toastAlert({ message: args.message || "hello", timeout: args.timeout, iconType: args.iconType })}>useToastAlertHook</button>
     )
 }
 
+/**
+ * required `RecoilRoot` for `useToastAlert`
+ */
 export const useToastAlertHook = {
     render: (args) => {
         return (

--- a/packages/feedback/Toast/src/Toast.stories.tsx
+++ b/packages/feedback/Toast/src/Toast.stories.tsx
@@ -22,23 +22,11 @@ type Story = StoryObj<typeof meta>;
 export const Default= {
     render: () => {
         const [show, setShow] = useState(false);
-        const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
-        useEffect(() => {
-            if (show) {
-                timer.current = setTimeout(() => {
-                    setShow(false);
-                }, 3000);
-            }
-            return () => {
-                clearTimeout(timer.current);
-            };
-        }, [show]);
 
         return (
             <div>
-                <button onClick={() => setShow(true)} disabled={show}>toast</button>
-                <Toast show={show} message={'hello'} />
+                <button onClick={() => setShow(true)}>toast</button>
+                <Toast show={show} message={'hello'} onClose={() => setShow(false)}/>
             </div>
         )
     }

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-import { RecoilRoot, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { toastAlertAtom } from './Recoil/Toast';
 

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -47,7 +47,7 @@ const RootToast = ({
         }
     }, []);
 
-    if (!message || JSON.stringify(message) === JSON.stringify({})) {
+    if (!message) {
         return null;
     }
 

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -12,18 +12,18 @@ const RootToast = ({
     open, onClose,
     message, timeout = 3000, iconType
 } : {
-    open: boolean, onClose?: () => void, 
+    open: boolean, onClose?: (e?: React.MouseEvent<HTMLElement, MouseEvent>) => void, 
     message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" | undefined
 }) => {
     const [animationState, setAnimationState] = useState<'FadeIn' | 'FadeOut' | 'Close'>('Close');
 
     const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-    const handleClose = useCallback(() => {
+    const handleClose = useCallback((e?: React.MouseEvent<HTMLElement, MouseEvent>) => {
         setAnimationState('FadeOut');
         
         if (!!onClose) {
-            closeTimer.current = setTimeout(onClose, ANIMATION_DURATION);
+            closeTimer.current = setTimeout(() => onClose(e), ANIMATION_DURATION);
         }
     }, [onClose]);
 
@@ -47,9 +47,7 @@ const RootToast = ({
         }
     }, []);
 
-    if (!message || 
-        JSON.stringify(message) === JSON.stringify({})
-    ) {
+    if (!message || JSON.stringify(message) === JSON.stringify({})) {
         return null;
     }
 

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -9,10 +9,10 @@ import './Toast.scss';
 const ANIMATION_DURATION = 287;
 
 const RootToast = ({ 
-    show, onClose,
+    open, onClose,
     message, timeout = 3000, iconType
 } : {
-    show: boolean, onClose?: () => void, 
+    open: boolean, onClose?: () => void, 
     message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" 
 }) => {
     const [animationState, setAnimationState] = useState<'FadeIn' | 'FadeOut' | 'Close'>('Close');
@@ -30,7 +30,7 @@ const RootToast = ({
     }, [onClose]);
 
     useEffect(() => {
-        if (!show) {
+        if (!open) {
             return;
         }
 
@@ -41,7 +41,7 @@ const RootToast = ({
         return ()=>{
             clearTimeout(timer);
         }
-    }, [message, timeout, show]);
+    }, [message, timeout, open]);
 
     useEffect(() => {
         return () => {
@@ -71,12 +71,12 @@ const RootToast = ({
 }
 
 export const GlobalToast = () => {
-    const { show, message, timeout, iconType } = useRecoilValue(toastAlertAtom);
+    const { open, message, timeout, iconType } = useRecoilValue(toastAlertAtom);
     const setToastAlertAtom = useSetRecoilState(toastAlertAtom);
 
     return (
         <RecoilRoot>
-            <RootToast show={show} onClose={() => setToastAlertAtom({show: false, message: ''})} {...{message, timeout, iconType}} />
+            <RootToast open={open} onClose={() => setToastAlertAtom({open: false, message: ''})} {...{message, timeout, iconType}} />
         </RecoilRoot>
     );
 }

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -13,12 +13,11 @@ const RootToast = ({
     message, timeout = 3000, iconType
 } : {
     open: boolean, onClose?: () => void, 
-    message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" 
+    message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" | undefined
 }) => {
     const [animationState, setAnimationState] = useState<'FadeIn' | 'FadeOut' | 'Close'>('Close');
 
     const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
 
     const handleClose = useCallback(() => {
         setAnimationState('FadeOut');
@@ -26,7 +25,6 @@ const RootToast = ({
         if (!!onClose) {
             closeTimer.current = setTimeout(onClose, ANIMATION_DURATION);
         }
-
     }, [onClose]);
 
     useEffect(() => {
@@ -49,7 +47,9 @@ const RootToast = ({
         }
     }, []);
 
-    if (!message) {
+    if (!message || 
+        JSON.stringify(message) === JSON.stringify({})
+    ) {
         return null;
     }
 

--- a/packages/feedback/Toast/src/Toast.tsx
+++ b/packages/feedback/Toast/src/Toast.tsx
@@ -39,7 +39,7 @@ const RootToast = ({
         return ()=>{
             clearTimeout(timer);
         }
-    }, [message, timeout, open]);
+    }, [open, timeout, handleClose]);
 
     useEffect(() => {
         return () => {
@@ -75,9 +75,7 @@ export const GlobalToast = () => {
     const setToastAlertAtom = useSetRecoilState(toastAlertAtom);
 
     return (
-        <RecoilRoot>
-            <RootToast open={open} onClose={() => setToastAlertAtom({open: false, message: ''})} {...{message, timeout, iconType}} />
-        </RecoilRoot>
+        <RootToast open={open} onClose={() => setToastAlertAtom({open: false, message: ''})} {...{message, timeout, iconType}} />
     );
 }
 


### PR DESCRIPTION
```python
1. 왜 바꿨는지: PR의 목적을 적어주세요.
2. 영향 받을 수 있는 것들: 잠재적으로 이 PR에 의해 영향받을 수 있는 library, stylesheet, 동작방식 등을 적어주세요.
3. QA List: PR이 정상 작동한다면 기대되는 동작/나와선 안되는 동작을 체크리스트로 작성해주세요.
```

# 1. 왜 바꿨는지
- `Toast.tsx`의 useEffect에서 message가 변화할 때 fade-in, fade-out 에니메이션이 발생하여 message가 변하지 않았지만 toastAlert 함수를 호출할 때 토스트가 보이지 않는 문제가 있습니다.
- `css`: `width: 100vw` 대신 `right: 0; left: 0;`을 사용합니다.
- `useToastAlert`를 사용하는 스토리를 추가합니다.

### `RootToast`
일반적인 모달, 다이얼로그 등과 같이 `open`, `onClose` props를 추가합니다.

```tsx
const MyComponent = () => {
  const [open, setOpen] = useState(false);
  
  return (
    <div>
      <button onClick={() => setOpen(true)}>toast</button>
      <Toast open={open} message={'hello'} onClose={() => setOpen(false)}/>
    </div>
)}
```

### `useToastAlert`
- 함수로써 `toastAlert`을 사용하기 위한 외부 인터페이스의 변화는 없습니다.
- `useToastAlert`가 recoil의 atom state를 사용하고 있어 `open`를 멤버에 추가하였습니다.
- `useToastAlert`의 구현에서 함수 호출시 open를 true로 세팅합니다.
- `Toast` 컴포넌트의 onClose 이벤트에 openfalse로 세팅해줍니다.

# 2. 영향 받을 수 있는 것들
- `<Toast />`의 인터페이스가 변경되었습니다.
```diff
const RootToast = ({ 
>   open, onClose,
    message, timeout = 3000, iconType
} : {
>   open: boolean, onClose?: () => void, 
    message: React.ReactNode, timeout?: number, iconType?: "error" | "success" | "warning" | "info" 
}) => {
```

# 3. QA List
- [ ] 
