### PR TITLE
[Docs] 스토리북 docs의 릴리즈 노트 카드의 화살표 방향을 올바르게 합니다.

### DIFF
--- a/docs/src/Component/ReleaseNote.js
+++ b/docs/src/Component/ReleaseNote.js
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
 import { Card, List, ListItem } from '@material-ui/core';
-import { KeyboardArrowUp } from '@material-ui/icons';
+import { KeyboardArrowDown } from '@material-ui/icons';
+import { useEffect, useState } from 'react';
 
 import ReactMarkdown from 'react-markdown';
 import { getReleaseNote } from '../Data/Release';
@@ -44,7 +44,7 @@ const ReleaseNote = () => {
                                             </h1>
                                             <span>{`update time: ${updateDateString}`}</span>
                                         </div>
-                                        <KeyboardArrowUp className={'Arrow'}/>
+                                        <KeyboardArrowDown className={'Arrow'}/>
                                     </summary>
                                     <div className={'ReleaseBody'}>
                                         <ReactMarkdown


### PR DESCRIPTION
```python
1. 왜 바꿨는지: PR의 목적을 적어주세요.
2. 영향 받을 수 있는 것들: 잠재적으로 이 PR에 의해 영향받을 수 있는 library, stylesheet, 동작방식 등을 적어주세요.
3. QA List: PR이 정상 작동한다면 기대되는 동작/나와선 안되는 동작을 체크리스트로 작성해주세요.
```

# 1. 왜 바꿨는지
- 릴리즈 카드의 화살표가 반대로 되어있어 이를 수정합니다.

# 2. 영향 받을 수 있는 것들
-

# 3. QA List
- [ ] 
